### PR TITLE
 Add game version logging on game start

### DIFF
--- a/Assets/Exanite.Arpg/Gameplay/LogGameVersion.cs
+++ b/Assets/Exanite.Arpg/Gameplay/LogGameVersion.cs
@@ -4,6 +4,9 @@ using ILogger = Serilog.ILogger;
 
 namespace Exanite.Arpg.Gameplay
 {
+    /// <summary>
+    /// Used to log the current game version
+    /// </summary>
     public class LogGameVersion : MonoBehaviour
     {
         private ILogger log;
@@ -16,7 +19,10 @@ namespace Exanite.Arpg.Gameplay
             LogCurrentVersion();
         }
 
-        private void LogCurrentVersion()
+        /// <summary>
+        /// Logs the current game version
+        /// </summary>
+        public void LogCurrentVersion()
         {
             log.Information("The current version of the game is {Version}", Application.version);
         }

--- a/Assets/Exanite.Arpg/Gameplay/LogGameVersion.cs
+++ b/Assets/Exanite.Arpg/Gameplay/LogGameVersion.cs
@@ -1,0 +1,24 @@
+﻿using UnityEngine;
+using Zenject;
+using ILogger = Serilog.ILogger;
+
+namespace Exanite.Arpg.Gameplay
+{
+    public class LogGameVersion : MonoBehaviour
+    {
+        private ILogger log;
+
+        [Inject]
+        public void Inject(ILogger log)
+        {
+            this.log = log.ForContext<LogGameVersion>();
+
+            LogCurrentVersion();
+        }
+
+        private void LogCurrentVersion()
+        {
+            log.Information("The current version of the game is {Version}", Application.version);
+        }
+    } 
+}

--- a/Assets/Exanite.Arpg/Gameplay/LogGameVersion.cs.meta
+++ b/Assets/Exanite.Arpg/Gameplay/LogGameVersion.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 27f77bccd83449745873fde1fc501d42
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/[Project]/Resources/ProjectContext.prefab
+++ b/Assets/[Project]/Resources/ProjectContext.prefab
@@ -1,5 +1,48 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4790901723418594819
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8054859317056463343}
+  - component: {fileID: 8332751827396048322}
+  m_Layer: 0
+  m_Name: LogGameVersion
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8054859317056463343
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4790901723418594819}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 8146128254948537754}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8332751827396048322
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4790901723418594819}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 27f77bccd83449745873fde1fc501d42, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &6038630721624788276
 GameObject:
   m_ObjectHideFlags: 0
@@ -29,6 +72,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 2026652845376501958}
+  - {fileID: 8054859317056463343}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -121,7 +121,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 0.1
+  bundleVersion: Dev
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0


### PR DESCRIPTION
This is to mainly test if `webbertakken/unity-builder` sets `Application.version` when it is building, but can also provide extra debug information.